### PR TITLE
adaptating extension and test for windows

### DIFF
--- a/configurations/.eslintrc.js
+++ b/configurations/.eslintrc.js
@@ -60,6 +60,7 @@ module.exports = {
         importOrder: [],
         importOrderSeparation: true,
         importOrderSortSpecifiers: true,
+        endOfLine: 'crlf',
       },
     ],
   },

--- a/src/commands/completeInlineTasks.test.ts
+++ b/src/commands/completeInlineTasks.test.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 
 suite('VSCode Extension Command Tests', function () {
   // Increased timeout since these are using LLM an are thus slow
-  this.timeout(60_000)
+  this.timeout(100_000)
   test('ai-task.completeInlineTasks command', async () => {
     /*
      *Assuming there's a file called "helloWorld.ts" in the root workspace:
@@ -65,12 +65,13 @@ suite('VSCode Extension Command Tests', function () {
     const helloWorldDocument =
       await vscode.workspace.openTextDocument(helloWorldUri)
     const helloWorldDocumentText = helloWorldDocument.getText()
+
+    const endOfLine =
+      helloWorldDocument.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n'
+
     assert.equal(
       helloWorldDocumentText,
-      `export function helloWorld(name: string) {
-  console.log(\`Hello \${name}!\`)
-}
-`,
+      `export function helloWorld(name: string) {${endOfLine}  console.log(\`Hello \${name}!\`)${endOfLine}}${endOfLine}`,
     )
 
     // Test creation of new files works
@@ -88,7 +89,9 @@ suite('VSCode Extension Command Tests', function () {
      * Clean up after the test (for some reason does not actually clean
      * anything up)
      */
-    await vscode.workspace.fs.delete(readmeUri)
-    await vscode.workspace.fs.delete(lsTestOutputUri)
+    /*
+     *await vscode.workspace.fs.delete(readmeUri)
+     *await vscode.workspace.fs.delete(lsTestOutputUri)
+     */
   })
 })

--- a/src/context/documentSnapshot.ts
+++ b/src/context/documentSnapshot.ts
@@ -155,7 +155,11 @@ import {
 } from 'vscode'
 
 import { Result, resultMap } from '../helpers/result'
-import { FileContext, transformFileContextWithLineNumbers } from './types'
+import {
+  FileContext,
+  replaceEndOfLineCRLFWithLF,
+  transformFileContextWithLineNumbers,
+} from './types'
 
 export interface LineRange {
   start: number
@@ -193,12 +197,22 @@ export class DocumentSnapshot {
    * Is it still accessible?
    * Maybe write a simple Unittest to test this similar to how I did with
    * VSCode edit apis
+   *
+   * There was a problem where the extension did not work on windows
+   * replaceEndOfLineCRLFWithLF helps to fix this by replacing CRLF with LF,
+   * instead of changing the codes \n to \r\n in everything, we adapt the text
+   * at the beginning
    */
   constructor(
     public document: TextDocument,
     public includeLineNumbers: boolean,
   ) {
     this.fileSnapshotForLlm = createFileContext(document)
+
+    this.fileSnapshotForLlm = replaceEndOfLineCRLFWithLF(
+      this.fileSnapshotForLlm,
+    )
+
     if (includeLineNumbers) {
       this.fileSnapshotForLlm = transformFileContextWithLineNumbers(
         this.fileSnapshotForLlm,

--- a/src/context/documentSnapshotCRLF.test.ts
+++ b/src/context/documentSnapshotCRLF.test.ts
@@ -3,15 +3,15 @@ import * as assert from 'assert'
 
 import { DocumentSnapshot, vscodeRangeToLineRange } from './documentSnapshot'
 
-suite('DocumentSnapshot', () => {
+suite('DocumentSnapshot CRLF', () => {
   setup(async () => {
     // Close all editors prior to opening new ones
     await vscode.commands.executeCommand('workbench.action.closeAllEditors')
   })
 
   test('Works correctly on a simple example from the API design', async function () {
-    const initialContent = `Line 0\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5`
-    const expectedContentAfterEdits = `Prepended New Line 0\nLine 0\nReplaced Line 1\nLine 2\nReplaced Line 3\nAdded Line 4\nLine 4\nLine 5`
+    const initialContent = `Line 0\r\nLine 1\r\nLine 2\r\nLine 3\r\nLine 4\r\nLine 5`
+    const expectedContentAfterEdits = `Prepended New Line 0\r\nLine 0\r\nReplaced Line 1\r\nLine 2\r\nReplaced Line 3\r\nAdded Line 4\r\nLine 4\r\nLine 5`
     const doc = await vscode.workspace.openTextDocument({
       content: initialContent,
     })

--- a/src/context/manager.ts
+++ b/src/context/manager.ts
@@ -74,8 +74,8 @@ export class SessionContextManager {
 
   /**
    * Is used as a cache for file paths that are matched against when resolving
-   * changes produced by LLM. Ideally we also want a session scope cache for all
-   * the files. This will do for now
+   * changes produced by LLM. Ideally we also want a session scope cache for
+   * all the files. This will do for now
    */
   getEditableFileUris(): vscode.Uri[] {
     return Array.from(this.uriToDocumentsSnapshots.keys()).map((uri) =>

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -21,3 +21,12 @@ export function transformFileContextWithLineNumbers(
     content: snapshotContent,
   }
 }
+
+// this function changes the СRLF to LF, helps with adaptation to windows
+export function replaceEndOfLineCRLFWithLF(fileContext: FileContext) {
+  const snapshotContent = fileContext.content.replace(/\r\n/g, '\n')
+  return {
+    ...fileContext,
+    content: snapshotContent,
+  }
+}

--- a/src/multi-file-edit/v1/resolveTargetRange.ts
+++ b/src/multi-file-edit/v1/resolveTargetRange.ts
@@ -104,7 +104,6 @@ export const makeToResolvedChangesTransformer = (
         const rangeToReplace = findTargetRangeInFileWithContent(
           change.oldChunk,
           documentSnapshot.fileSnapshotForLlm.content,
-          documentSnapshot.document.eol,
         )
 
         if (!rangeToReplace) {
@@ -188,9 +187,8 @@ export const makeToResolvedChangesTransformer = (
 export function findTargetRangeInFileWithContent(
   oldChunk: TargetRange,
   documentContent: string,
-  documentEndOfLine: vscode.EndOfLine,
 ): vscode.Range | undefined {
-  const eofString = documentEndOfLine === vscode.EndOfLine.CRLF ? '\r\n' : '\n'
+  const eofString = '\n'
   const fileLines = documentContent.split(eofString)
 
   /**

--- a/src/multi-file-edit/v1/targetRange.test.ts
+++ b/src/multi-file-edit/v1/targetRange.test.ts
@@ -1,0 +1,51 @@
+import assert = require('assert')
+import { findTargetRangeInFileWithContent } from './resolveTargetRange'
+import { TargetRange } from './types'
+import * as vscode from 'vscode'
+
+suite('findTargetRangeInFileWithContent', () => {
+  test('should return undefined for non-matching content', () => {
+    const oldChunk: TargetRange = {
+      type: 'fullContentRange',
+      isStreamFinalized: true,
+      fullContent: 'nonexistent',
+    }
+    const documentContent = 'Hello\nWorld'
+    const result = findTargetRangeInFileWithContent(oldChunk, documentContent)
+    assert.ok(!result)
+  })
+
+  test('should handle empty document content', () => {
+    const oldChunk: TargetRange = {
+      type: 'fullContentRange',
+      isStreamFinalized: true,
+      fullContent: '',
+    }
+    const documentContent = ''
+    const result = findTargetRangeInFileWithContent(oldChunk, documentContent)
+    assert.deepStrictEqual(result, new vscode.Range(0, 0, 0, 0))
+  })
+
+  test('should handle single line replacement', () => {
+    const oldChunk: TargetRange = {
+      type: 'fullContentRange',
+      isStreamFinalized: true,
+      fullContent: 'Hello',
+    }
+    const documentContent = 'Hello\nWorld'
+    const result = findTargetRangeInFileWithContent(oldChunk, documentContent)
+    assert.deepStrictEqual(result, new vscode.Range(0, 0, 0, 5))
+  })
+
+  test('should handle prefix and suffix range', () => {
+    const oldChunk: TargetRange = {
+      type: 'prefixAndSuffixRange',
+      isStreamFinalized: true,
+      prefixContent: 'Hello',
+      suffixContent: 'World',
+    }
+    const documentContent = 'Hello\nThis is a test\nWorld'
+    const result = findTargetRangeInFileWithContent(oldChunk, documentContent)
+    assert.deepStrictEqual(result, new vscode.Range(0, 0, 2, 5))
+  })
+})


### PR DESCRIPTION
# Adaptating extension and tests for windows

## Issue: 
- When installing the extension on windows, it did not work due to different encodings on unix and windows (CLRF and LF)
https://github.com/bra1nDump/ai-task-vscode/issues/11
 
## Solution: 
- At the beginning there was an attempt to change the code in many places with the addition of changing the separator character from \n to \r\n (checking the document for the EndOfLine property). After unsuccessful attempts, it was decided to replace all occurrences of \r\n with \n in one place, which gave the result. In fact, the code only needed to be changed in one place (documnetSnapshot)
- Some tests have also been added and the old ones have been adapted for windows