### PR TITLE
Moving to Notebook interface to show file editing progress and add chat functionality

### DIFF
--- a/configurations/.eslintrc.js
+++ b/configurations/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     // Add your custom rules here
     "@typescript-eslint/no-explicit-any": "off",
     "unused-imports/no-unused-imports": "warn",
+    "@typescript-eslint/require-await": "off",
 
     // Currently annoying as we have a lot of bootstraping code, lets fix later
     "@typescript-eslint/no-unused-vars": "off",

--- a/documents/backlog.md
+++ b/documents/backlog.md
@@ -33,10 +33,15 @@ Now all actual file editing is kicked off from the notebook execution
 - Editing is happening not in the original tab group, but in the group with the notebook. We should keep the notebook visible and open the files in the original group. I think this can be accessed from tabs api. Search tabs in the codebase.
 
 ## If we have time
+- Allow writing custom tasks in the notebook and actually running file editing on those
+- There is some command @command:notebook.action.toggleNotebookStickyScroll (open command pallet and explore "Notebook: " commands). No idea what this does, but might help with keeping the bottom part visible
+
+
+## Later - after the demo
 - When adding a task in a followup - include the output of the non-editing commands in the context.
   - This is useful if the user asks a question and when they like the answer (code related) they can run a task to apply them to the code instead of copy pasting and having to specify the same task 
   - This will also give better overall results because the prompt is easier when generating initial code suggestions - no mulit file edit. Next the multi-file edit can just focus on applying the known changes to the code - harder to fuck up
-- There is some command @command:notebook.action.toggleNotebookStickyScroll (open command pallet and explore "Notebook: " commands). No idea what this does, but might help with keeping the bottom part visible
+- Output markdown flickers - we should replace output with actual markdown cells so we can edit them inrementally to avoid this
 
 # Later
 

--- a/documents/backlog.md
+++ b/documents/backlog.md
@@ -11,20 +11,32 @@
 
 # Before our demos
 
-When user hits run - we create a new notebook 
-  Ideally with the task that kicked off being included in the notebook's cell (for now we will just say "@task is in the code")
-  We programmatically start executing the first cell
+## New control flow
 
-On cell execution:
+When user hits run (or runs command from command palette)
+  - we create a new notebook
+  - open it
+  - do gynmnastics to add a new cell to it using commands (so if its already opend we append to the end)
+  - start executing the cell
+
+Now all actual file editing is kicked off from the notebook execution
   - We create a new session, given the cell execution to append high level results to
-  - If the cell does not have a task in it - use a simplified prompt that will dump context manager + previous cell contents into the messages
+  - If the cell does not have a task in it
+    - Similar to how we do this in completeInlineTasks, parse the cell content for @ mentions and modify context
+    - use a simplified prompt to simply generate markdown reponse - no edits
+    - dump context manager + previous cell contents into the messages
 
-When user uses @task @tabs etc in the notebook we create the correct context and run the task.
-When user does followup tasks - we add these to the
+## Fixups:
+- Create a cell with markdown showing discord link
+- Smaller heading size for files / task etc - takes too much space
+- In output remove start / end messages - redundant
+- Editing is happening not in the original tab group, but in the group with the notebook. We should keep the notebook visible and open the files in the original group. I think this can be accessed from tabs api. Search tabs in the codebase.
 
-- Read Ivan's code
-- If task is mentioned - kick off task execution. Create a session per cell?
-- Keep the history of the chat
+## If we have time
+- When adding a task in a followup - include the output of the non-editing commands in the context.
+  - This is useful if the user asks a question and when they like the answer (code related) they can run a task to apply them to the code instead of copy pasting and having to specify the same task 
+  - This will also give better overall results because the prompt is easier when generating initial code suggestions - no mulit file edit. Next the multi-file edit can just focus on applying the known changes to the code - harder to fuck up
+- There is some command @command:notebook.action.toggleNotebookStickyScroll (open command pallet and explore "Notebook: " commands). No idea what this does, but might help with keeping the bottom part visible
 
 # Later
 

--- a/documents/backlog.md
+++ b/documents/backlog.md
@@ -26,14 +26,20 @@ Now all actual file editing is kicked off from the notebook execution
     - use a simplified prompt to simply generate markdown reponse - no edits
     - dump context manager + previous cell contents into the messages
 
-## Fixups:
+## Next up:
+This is useful as there will be new people trying the product
+- Add a shortcut to create a new notebook
+- Add a walkthrough that will show how to create a new notebook (it will be created in the session folder)
+
+Better format is better :D
 - Create a cell with markdown showing discord link
 - Smaller heading size for files / task etc - takes too much space
 - In output remove start / end messages - redundant
-- Editing is happening not in the original tab group, but in the group with the notebook. We should keep the notebook visible and open the files in the original group. I think this can be accessed from tabs api. Search tabs in the codebase.
+- Don't show output of files submitted and others if there is no need
 
 ## If we have time
 - Allow writing custom tasks in the notebook and actually running file editing on those
+- This would require passing the custom @ task command to the completeInlineTasks function and passing it in correctly to the context manager or as a message.
 - There is some command @command:notebook.action.toggleNotebookStickyScroll (open command pallet and explore "Notebook: " commands). No idea what this does, but might help with keeping the bottom part visible
 
 
@@ -42,6 +48,14 @@ Now all actual file editing is kicked off from the notebook execution
   - This is useful if the user asks a question and when they like the answer (code related) they can run a task to apply them to the code instead of copy pasting and having to specify the same task 
   - This will also give better overall results because the prompt is easier when generating initial code suggestions - no mulit file edit. Next the multi-file edit can just focus on applying the known changes to the code - harder to fuck up
 - Output markdown flickers - we should replace output with actual markdown cells so we can edit them inrementally to avoid this
+
+Error: 
+rejected promise not handled within 1 second: Error: Cannot modify cell output after calling resolve
+extensionHostProcess.js:131
+stack trace: Error: Cannot modify cell output after calling resolve
+	at h.t (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:127:105565)
+	at Object.replaceOutput (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:127:107002)
+	at applyEdit (/Users/kirilldubovitskiy/projects/bread/dist/extension.js:1247:25)
 
 # Later
 

--- a/documents/backlog.md
+++ b/documents/backlog.md
@@ -9,7 +9,26 @@
 - Reached out to 5 potential collaborators
 - Replaced continue on the current project
 
-# Next up
+# Before our demos
+
+When user hits run - we create a new notebook 
+  Ideally with the task that kicked off being included in the notebook's cell (for now we will just say "@task is in the code")
+  We programmatically start executing the first cell
+
+On cell execution:
+  - We create a new session, given the cell execution to append high level results to
+  - If the cell does not have a task in it - use a simplified prompt that will dump context manager + previous cell contents into the messages
+
+When user uses @task @tabs etc in the notebook we create the correct context and run the task.
+When user does followup tasks - we add these to the
+
+- Read Ivan's code
+- If task is mentioned - kick off task execution. Create a session per cell?
+- Keep the history of the chat
+
+# Later
+
+Split up different user requests into different openai user messages. This will be closer to what the chat is used to do - adjust based on the user input.
 
 Stability
 - change prompt for new files for stability (just remove range-to-replace)

--- a/documents/use-cases.md
+++ b/documents/use-cases.md
@@ -137,3 +137,8 @@ Basically create an onboarding for an issue. Same infra than for the previous id
 # Watch the data
 The diagram comes in - I want to watch all transformations it goes through and get code pointers.
 Its similar to profiling / tracing but for data transformations
+
+# Search old code in your repo (that you removed say)
+And re-apply to the current code base
+
+# Resolve merge conflicts

--- a/documents/use-cases.md
+++ b/documents/use-cases.md
@@ -142,3 +142,6 @@ Its similar to profiling / tracing but for data transformations
 And re-apply to the current code base
 
 # Resolve merge conflicts
+
+# Show recent edits and figure out what the fuck was i doing ...
+Seems like a good plugin feature contributed by users?

--- a/package.json
+++ b/package.json
@@ -31,6 +31,28 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "notebooks": [
+      {
+        "type": "task-notebook",
+        "displayName": "Task Notebook",
+        "selector": [
+          {
+            "filenamePattern": "*.task"
+          }
+        ]
+      }
+    ],
+    "languages": [
+      {
+        "id": "task-book",
+        "aliases": [
+          "Task Book"
+        ],
+        "filenamePatterns": [
+          "*.task"
+        ]
+      }
+    ],
     "commands": [
       {
         "command": "ai-task.completeInlineTasks",
@@ -56,6 +78,19 @@
         "ai-task.userId": {
           "type": "string",
           "description": "User ID to use for by default anonymous analytics"
+        },
+        "ai-task.markdownOrNotebook": {
+          "type": "string",
+          "default": "notebook",
+          "enum": [
+            "notebook",
+            "markdown"
+          ],
+          "enumDescriptions": [
+            "notebook output",
+            "markdown output"
+          ],
+          "description": "Output of the main logs to a markdown document or notebook"
         }
       }
     },
@@ -78,10 +113,10 @@
     "------------section-test------------": "",
     "test": "npm run build && node out/test/runTest.js",
     "------------section-extension-packaging-and-publishing------------": "Refactor: move package + publishing to the install-local script and have it accept --publish --package-and-install-local",
-    "package": "npm run build && ./node_modules/.bin/vsce package --ignoreFile configurations/.vscodeignore --no-dependencies --ignoreFile  configurations/.vscodeignore --allow-star-activation --githubBranch main",
+    "package": "npm run build && .\\node_modules\\.bin\\vsce package --ignoreFile configurations\\.vscodeignore --no-dependencies --ignoreFile  configurations\\.vscodeignore --allow-star-activation --githubBranch main",
     "publish": "npm run test && npm run bundle:prod && ./node_modules/.bin/vsce publish --no-dependencies --ignoreFile  configurations/.vscodeignore --allow-star-activation --githubBranch main",
     "publish:bypass-test": "npm run bundle:prod && ./node_modules/.bin/vsce publish --no-dependencies --ignoreFile  configurations/.vscodeignore --allow-star-activation --githubBranch main",
-    "install-local": "node scripts/install-local.mjs 'code-insiders'",
+    "install-local": "node scripts/install-local.mjs code",
     "------------section-other------------": "",
     "lint": "eslint . --config configurations/.eslintrc.js --ext ts --fix",
     "codegen:prompt-checkpoints": "MULTI_FILE_PROMPT_VERSION=v5-new-example-refactor-functions-with-similar-functionality node ./out/script-generate-prompt-checkpoint.js"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     ],
     "languages": [
       {
-        "id": "task-book",
+        "id": "task-notebook",
         "aliases": [
           "Task Book"
         ],

--- a/src/commands/questionAnswering.ts
+++ b/src/commands/questionAnswering.ts
@@ -1,0 +1,207 @@
+import * as vscode from 'vscode'
+import {
+  findAndCollectBreadMentionedFiles,
+  findAndCollectDotBreadFiles,
+} from 'context/atTask'
+import { getFilesContent } from 'helpers/fileSystem'
+import { SessionContext, getBreadIdentifier } from 'session'
+import { closeSession, startSession } from 'session'
+import { projectDiagnosticEntriesWithAffectedFileContext } from 'context/atErrors'
+import dedent from 'dedent'
+import { openedTabs } from 'context/atTabs'
+import { OpenAiMessage } from 'helpers/openai'
+import { startQuestionAnsweringStreamWIthContext } from 'multi-file-edit/v1/HACK_questionMessageCreation'
+
+//////////////////// THIS ENTIRE FILE IS A HACK - COPIED OVER FROM comleteInlineTasks ////////////////////
+
+/**
+ * This will now only get invoked from the notebook controller
+ *
+ * Generates and applies diffs to files in the workspace containing task
+ * mention.
+ *
+ * Collect all files in workspace with task mention
+ * Pack the files along with the diff generation prompts
+ * Call openai api (through langchain)
+ * Parse the diffs
+ * Apply them to the current file in place
+ */
+export async function answerQuestionCommand(
+  extensionContext: vscode.ExtensionContext,
+  sessionRegistry: Map<string, SessionContext>,
+  execution: vscode.NotebookCellExecution,
+  previousMessages: OpenAiMessage[],
+) {
+  if (sessionRegistry.size !== 0) {
+    console.log(`Existing session running, most likely a bug with @run + enter`)
+    return
+  }
+
+  const sessionContext = await startSession(extensionContext, execution)
+  sessionRegistry.set(sessionContext.id, sessionContext)
+
+  try {
+    /*
+     * This works differently from the completeInlineTasksCommand because it
+     * returns before we are done with the stream - it returns the stream itself
+     */
+    const stream = await throwingQuestionAnswering(
+      sessionContext,
+      previousMessages,
+    )
+
+    if (stream === undefined) {
+      throw new Error('Stream is undefined')
+    }
+
+    /*
+     * This is a hack to keep the first output (what files were submitted etc)
+     * if it exists before we start replying
+     */
+    const firstOutputWithContext = execution.cell.outputs.at(0)
+
+    for await (const answerString of stream) {
+      if (execution.token.isCancellationRequested) {
+        break
+      }
+      void execution.replaceOutput([
+        ...(firstOutputWithContext ? [firstOutputWithContext] : []),
+        new vscode.NotebookCellOutput([
+          vscode.NotebookCellOutputItem.text(answerString, 'text/markdown'),
+        ]),
+      ])
+    }
+
+    // For last output write
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  } catch (error) {
+    console.error(error)
+    if (error instanceof Error) {
+      await sessionContext.highLevelLogger(`\n\n> Error: ${error.message}`)
+    }
+  } finally {
+    // await sessionContext.highLevelLogger('\n\n> Done\n')
+
+    await closeSession(sessionContext)
+    sessionRegistry.delete(sessionContext.id)
+  }
+}
+
+async function throwingQuestionAnswering(
+  sessionContext: SessionContext,
+  previousMessages: OpenAiMessage[],
+) {
+  ////// Compile the context, pull in task files and other context based on mentions //////
+  const openTabsFileUris = openedTabs()
+
+  /*
+   * Only search for tasks in open tabs, we might want to keep the task
+   * unaddressed for the time being, but don't want to errase it
+   */
+  const breadIdentifier = getBreadIdentifier()
+  const fileUrisWithBreadMentions = await findAndCollectBreadMentionedFiles(
+    breadIdentifier,
+    openTabsFileUris,
+  )
+
+  await sessionContext.contextManager.addDocuments(
+    'Files with bread mentions',
+    fileUrisWithBreadMentions,
+  )
+
+  /* .task files */
+  const dotBreadFileUris = await findAndCollectDotBreadFiles(breadIdentifier)
+  const breadFileBlobs = await getFilesContent(dotBreadFileUris)
+  sessionContext.contextManager.addBlobContexts(breadFileBlobs)
+
+  /*
+   * Before we have proper task expression parsing,
+   * we will just search all task files for a mention of special
+   * sub-expressions
+   */
+  const breadMentionsFilesContent = await getFilesContent(
+    fileUrisWithBreadMentions,
+  )
+
+  /* Include open tabs if the user requested */
+  const includeTabs = [...breadMentionsFilesContent, ...breadFileBlobs].some(
+    (fileContent) => fileContent.includes('@' + 'tabs'),
+  )
+  if (includeTabs) {
+    await sessionContext.contextManager.addDocuments(
+      'Open tabs',
+      openTabsFileUris,
+    )
+  }
+
+  /*
+   * Provide problems context
+   * Include files with errors if the user requested
+   */
+  const includeErrors = [...breadMentionsFilesContent, ...breadFileBlobs].some(
+    (fileContent) => fileContent.includes('@' + 'errors'),
+  )
+  if (includeErrors) {
+    const diagnosticsAlongWithTheirFileContexts =
+      projectDiagnosticEntriesWithAffectedFileContext()
+    const filesWithErrors = diagnosticsAlongWithTheirFileContexts.map(
+      (x) => x.uri,
+    )
+    await sessionContext.contextManager.addDocuments(
+      'Files with errors',
+      filesWithErrors,
+    )
+
+    /*
+     * Provide optional problem context + prompt
+     * Refactor: This should move to a static context provider
+     */
+    const problemContext = diagnosticsAlongWithTheirFileContexts
+      .flatMap(({ uri, diagnostic }) => {
+        if (diagnostic.severity !== vscode.DiagnosticSeverity.Error) {
+          return []
+        }
+        const filePathRelativeToWorkspace = vscode.workspace.asRelativePath(uri)
+
+        return [
+          dedent(`
+            File: ${filePathRelativeToWorkspace}
+            Error message: ${diagnostic.message}
+            Range:
+            - Line start ${diagnostic.range.start.line}
+            - Line end ${diagnostic.range.end.line}
+            ${
+              diagnostic.relatedInformation
+                ?.map((info) => `Related info: ${info.message}`)
+                .join('\n') ?? ''
+            }
+            `),
+        ]
+      })
+      .join('\n')
+
+    if (problemContext.length !== 0) {
+      const compilationErrorContext = dedent(`
+        Here's a list of compilation errors in some of the files:
+        ${problemContext}
+
+        - Most likely this is due to a refactor user has started but not finished
+        - Based on @${breadIdentifier} mentions and the errors you should guess what was the refactor in the first place
+        - Collect all relevant information about the refactor that might help you fix the errors
+
+        Addressing errors:
+        - Often the location of the error is not the place that you want to make changes to
+        - Make sure you're not masking the compile error, but rather making necessary changes to the logic of the program
+        `)
+
+      sessionContext.contextManager.addBlobContexts([compilationErrorContext])
+    }
+  }
+
+  console.log('fileManager', sessionContext.contextManager.dumpState())
+
+  return await startQuestionAnsweringStreamWIthContext(
+    sessionContext,
+    previousMessages,
+  )
+}

--- a/src/commands/questionAnswering.ts
+++ b/src/commands/questionAnswering.ts
@@ -135,6 +135,26 @@ async function throwingQuestionAnswering(
   }
 
   /*
+   * Always include active text editor as the questions are likely to be
+   * related to it
+   */
+  if (vscode.window.visibleTextEditors.length) {
+    await sessionContext.contextManager.addDocuments(
+      'Visible text editor',
+      vscode.window.visibleTextEditors
+        .filter(
+          (editor) =>
+            /*
+             * Don't return files with .task in them,
+             * they are probably a notebook
+             */
+            !editor.document.uri.path.includes('.task'),
+        )
+        .map((editor) => editor.document.uri),
+    )
+  }
+
+  /*
    * Provide problems context
    * Include files with errors if the user requested
    */

--- a/src/context/atTabs.ts
+++ b/src/context/atTabs.ts
@@ -30,3 +30,8 @@ function tabsToUris(tabs: readonly vscode.Tab[]): vscode.Uri[] {
     }
   })
 }
+
+export function findTabsMatching(path: string): vscode.Uri[] {
+  const tabs = vscode.window.tabGroups.all.flatMap((tabGroup) => tabGroup.tabs)
+  return tabsToUris(tabs).filter((uri) => uri.path.includes(path))
+}

--- a/src/context/language-features/semanticTokensProvider.ts
+++ b/src/context/language-features/semanticTokensProvider.ts
@@ -41,7 +41,7 @@ export class TaskSemanticTokensProvider
     ]
     const specialExpressionsWithSpaces = specialExpressions
       // For highlighting lets ensure this is a stand alone keyword
-      .map((x) => ({ ...x, expression: ` ${x.expression}` }))
+      .map((x) => ({ ...x, expression: `${x.expression}` }))
 
     const linesWithExpressions = Array.from(
       { length: document.lineCount },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { completeInlineTasksCommand } from 'commands/completeInlineTasks'
+import { newCompleteInlineTasksCommandFromVSCodeCommand } from 'commands/completeInlineTasks'
 import { TaskExpressionCompletionItemProvider } from 'context/language-features/completionItemProvider'
 import { TaskCodeLensProvider } from 'context/language-features/codeLensProvider'
 import { TaskSemanticTokensProvider } from 'context/language-features/semanticTokensProvider'
@@ -13,7 +13,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Poor men's dependency injection
   const sessionRegistry = new Map<string, SessionContext>()
 
-  context.subscriptions.push(new TaskController())
+  context.subscriptions.push(new TaskController(context, sessionRegistry))
 
   context.subscriptions.push(
     vscode.workspace.registerNotebookSerializer(
@@ -34,7 +34,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'ai-task.completeInlineTasks',
       async () => {
-        await completeInlineTasksCommand(context, sessionRegistry)
+        await newCompleteInlineTasksCommandFromVSCodeCommand()
       },
       /*
        * TODO: this acctually accepts this as a third argument,
@@ -96,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext) {
          * Previously I was undoing the enter change,
          * but it introduces additional jitter to the user experience
          */
-        void completeInlineTasksCommand(context, sessionRegistry)
+        void newCompleteInlineTasksCommandFromVSCodeCommand()
       }
     }),
   )
@@ -127,7 +127,9 @@ export async function activate(context: vscode.ExtensionContext) {
       '@',
     ),
     vscode.languages.registerCodeLensProvider(
-      languageForFiles.filter((language) => language.language !== 'task-book'),
+      languageForFiles.filter(
+        (language) => language.language !== 'task-notebook',
+      ),
       new TaskCodeLensProvider(sessionConfiguration),
     ),
     vscode.languages.registerDocumentSemanticTokensProvider(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,10 +12,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Poor men's dependency injection
   const sessionRegistry = new Map<string, SessionContext>()
-  const commandWithBoundSession = completeInlineTasksCommand.bind({
-    extensionContext: context,
-    sessionRegistry,
-  })
 
   context.subscriptions.push(new TaskController())
 
@@ -37,7 +33,9 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.unshift(
     vscode.commands.registerCommand(
       'ai-task.completeInlineTasks',
-      commandWithBoundSession,
+      async () => {
+        await completeInlineTasksCommand(context, sessionRegistry)
+      },
       /*
        * TODO: this acctually accepts this as a third argument,
        * so bind above can be removed and this can be passed here insted
@@ -98,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext) {
          * Previously I was undoing the enter change,
          * but it introduces additional jitter to the user experience
          */
-        void commandWithBoundSession()
+        void completeInlineTasksCommand(context, sessionRegistry)
       }
     }),
   )

--- a/src/helpers/openai.ts
+++ b/src/helpers/openai.ts
@@ -12,6 +12,7 @@ import { undefinedIfStringEmpty } from './optional'
 import { Stream } from 'openai/streaming'
 import { APIError } from 'openai/error'
 import { hell } from './constants'
+import { taskAppendAnswerToOutput } from 'notebook/taskAppendAnswerToOutput'
 
 export type OpenAiMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam
 
@@ -212,4 +213,86 @@ export async function streamLlm(
     })
 
   return resultSuccess([multicastStream, stream.controller])
+}
+
+export async function getAnswer(
+  question: string,
+  execution: vscode.NotebookCellExecution,
+) {
+  const key: string | undefined =
+    process.env.OPENAI_API_KEY ??
+    undefinedIfStringEmpty(
+      vscode.workspace.getConfiguration('ai-task').get('openaiApiKey'),
+    )
+
+  const openai =
+    key === undefined
+      ? new OpenAI({
+          apiKey: `sk-helicone-proxy-${hell}`,
+          baseURL: 'https://oai.hconeai.com/v1',
+
+          defaultHeaders: {
+            /*
+             * Analytics, this header is kind of redundant but is still needed
+             * to have requests logged in the dashboard, discouraging simple
+             * scraping, this key is not important though
+             */
+            'Helicone-Auth':
+              `Bearer ` +
+              `s` +
+              `k` +
+              '-helicone' +
+              '-nw' +
+              '5' +
+              'a' +
+              '63' +
+              'y' +
+              '-333' +
+              'utiq' +
+              '-qs' +
+              '62' +
+              'fma' +
+              '-grnofmi',
+
+            'Helicone-User-Id': '1111',
+            // Do not store user's data
+            'Helicone-Omit-Request': 'true',
+            'Helicone-Omit-Response': 'true',
+          },
+        })
+      : new OpenAI({
+          apiKey: key,
+          baseURL: 'https://api.openai.com/v1',
+        })
+
+  if (execution.token.isCancellationRequested) {
+    return
+  }
+
+  const stream = await openai.chat.completions.create({
+    model: process.env.OPENAI_DEFAULT_MODEL ?? 'gpt-4',
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a helpful assistant.',
+      },
+      {
+        role: 'user',
+        content: question,
+      },
+    ],
+    stream: true,
+  })
+
+  let result = ''
+  for await (const response of stream) {
+    if (execution.token.isCancellationRequested) {
+      return
+    }
+    const delta = response.choices[0]?.delta?.content
+    result += delta
+    if (delta) {
+      taskAppendAnswerToOutput(execution, result)
+    }
+  }
 }

--- a/src/multi-file-edit/applyResolvedChange.ts
+++ b/src/multi-file-edit/applyResolvedChange.ts
@@ -163,7 +163,9 @@ async function highlightTargetRangesAsTheyBecomeAvailable(
       // Show the editor if it is not already shown
       if (!shownEditorAndRevealedRange.has(index)) {
         // Decorations can only be set on active editors
-        const editor = await vscode.window.showTextDocument(change.fileUri)
+        const editor = await vscode.window.showTextDocument(change.fileUri, {
+          viewColumn: vscode.ViewColumn.One,
+        })
 
         // We want to show the user the area we're updating
         editor.revealRange(
@@ -248,7 +250,11 @@ async function showFilesOnceWeKnowWeWantToModifyThem(
         const document = await vscode.workspace.openTextDocument(change.fileUri)
         const relativeFilepath = vscode.workspace.asRelativePath(change.fileUri)
         void context.highLevelLogger(`\n### Modifying ${relativeFilepath}\n`)
-        await vscode.window.showTextDocument(document)
+
+        // A better solution is to use findTabsMatching
+        await vscode.window.showTextDocument(document, {
+          viewColumn: vscode.ViewColumn.One,
+        })
         shownChangeIndexes.add(change.fileUri.fsPath)
       }
     }
@@ -278,7 +284,10 @@ export async function applyResolvedChangesWhileShowingTheEditor(
   const document = await vscode.workspace.openTextDocument(
     resolvedChange.fileUri,
   )
-  const editor = await vscode.window.showTextDocument(document)
+  // A better solution is to use findTabsMatching
+  const editor = await vscode.window.showTextDocument(document, {
+    viewColumn: vscode.ViewColumn.One,
+  })
 
   /*
    *This will throw if the editor has been de allocated!

--- a/src/multi-file-edit/v1/HACK_questionAnsweringPrompt.ts
+++ b/src/multi-file-edit/v1/HACK_questionAnsweringPrompt.ts
@@ -1,0 +1,135 @@
+import { FileContext } from 'context/types'
+import { OpenAiMessage } from 'helpers/openai'
+import { SessionConfiguration } from 'session'
+
+/**
+ * HACCCCCK
+ * COPIED OVER FROM pompt.ts
+ */
+
+export function createQuestionAnsweringWithContext(
+  fileContexts: FileContext[],
+  blobContexts: string[],
+  configuration: SessionConfiguration,
+): OpenAiMessage[] {
+  // Dynamic messages based on input
+  const filesContextXmlPrompt = fileContexts.map(mapFileContextToXml).join('\n')
+
+  // For example compilation errors or blobs of documentation
+  let optionalStaticContent = ''
+  if (blobContexts.length > 0) {
+    optionalStaticContent =
+      blobContexts
+        .map(
+          (blobContext) =>
+            `<information-blob>${blobContext}</information-blob>`,
+        )
+        .join('\n') + '\n\n'
+  }
+
+  /*
+   * Do we need to say your input? Doesn't matter for performance using a
+   * system or user message? It feels like I should be using the user here
+   */
+  const inputWithFiles: OpenAiMessage = {
+    content: optionalStaticContent + filesContextXmlPrompt,
+    role: 'user',
+  }
+
+  ////////// KEEEEY DIFFERENCE PROMPT //////////
+  const messages = [
+    {
+      content:
+        'You will get files, and some other relevant information. You will also get a history of the conversation so far. Reply with markdown. You might not have all the information provided to you, try to reply to the best of your abilities. You are a coding assistant.',
+      role: 'system',
+    } as OpenAiMessage,
+    inputWithFiles,
+  ]
+  return messages
+}
+
+/**
+ * Encode the file contexts into a prompt for the model
+ * @param fileContexts - The files to encode
+ * @param includeLineNumbers - Whether to include line numbers in the prompt. Keeping this as a parameter to quantify improvements or regressions
+ */
+
+function mapFileContextToXml(fileContext: FileContext): string {
+  return (
+    '<file>\n' +
+    `<path>${fileContext.filePathRelativeToWorkspace}</path>\n` +
+    `<content>\n${fileContext.content}\n</content>\n` +
+    '</file>'
+  )
+}
+
+/*
+ * // range-(start|end)-<id> is used to mark the range to replace in the input.
+ * This function removes those annotations from the input before sumbitting it to llm
+ */
+function removeRangeAnnotations(text: string): string {
+  return text.replace(/\s*\/\/\s*range-(start|end)\S*/g, '')
+}
+
+/**
+ * This function overall sucks because its flacky, should probably error out if
+ * multiple matches are found, instead I will return last one for end term and
+ * first one for start term.
+ *
+ * If there are multiple matches, use // range-(start|end)-<range-id> annotations.
+ * These will be stripped from the range string.
+ *
+ * I'm using a content based to find the target range because the line
+ * numbers are implicit and I don't want to keep truck of them in case they
+ * change in the future or their format changes.
+ *
+ * This function extracts the target range from the content passed in and
+ * truncates it if it's over five lines.
+ *
+ * Not exactly sure how I will handle cases when we will stop providing
+ * content in the range to replace. Could be handled similarly except for
+ * dropping the content of the line.
+ *
+ * The algorithm is roughly:
+ * Split content within the editable file content into lines
+ * Find the line with the content from the first line for the range to
+ * replace, in our case space <ul>
+ * Find the line with the content from the last line for the range to replace
+ * Concatenate hold the lines within the range and put into a variable.
+ */
+function extractMatchingLineRange(
+  content: string,
+  startTerm: string,
+  endTerm: string,
+): string {
+  const lines = content.split('\n')
+  const startLineIndex = lines.findIndex((line) => line.includes(startTerm))
+  // Find last index of the end term
+  const endLineIndex =
+    lines.length -
+    1 -
+    [...lines].reverse().findIndex((line) => line.includes(endTerm))
+  let lineRange = lines.slice(startLineIndex, endLineIndex + 1)
+
+  /*
+   * Including two lines in the front and in the end because the last line
+   * would often be a closing bracket which might make it harder for the modal
+   * to reason about the range ending
+   *
+   * Currently unused
+   */
+  if (lineRange.length > 3) {
+    lineRange = [
+      ...lineRange.slice(0, 2),
+      '<truncated/>',
+      ...lineRange.slice(lineRange.length - 2),
+    ]
+  }
+
+  const rangeWithPossibleAnnotations = lineRange.join('\n')
+  const rangeWithoutAnnotations = removeRangeAnnotations(
+    rangeWithPossibleAnnotations,
+  )
+
+  return rangeWithoutAnnotations
+}

--- a/src/multi-file-edit/v1/HACK_questionMessageCreation.ts
+++ b/src/multi-file-edit/v1/HACK_questionMessageCreation.ts
@@ -1,0 +1,92 @@
+import * as vscode from 'vscode'
+
+import { FileContext } from 'context/types'
+import { OpenAiMessage, streamLlm } from 'helpers/openai'
+import { from } from 'ix/asynciterable'
+
+import { SessionContext } from 'session'
+
+import { map as mapAsync } from 'ix/asynciterable/operators'
+import { createQuestionAnsweringWithContext } from './HACK_questionAnsweringPrompt'
+
+export async function startQuestionAnsweringStreamWIthContext(
+  sessionContext: SessionContext,
+  messagesInput: OpenAiMessage[],
+) {
+  /*
+   * WARNING - dependin on plaform line separators might be different!!!
+   * \n, on windows we want to convert to that at some point??
+   *
+   * Figure out how to write some tests to trigger the current bugs more
+   * locally?
+   * Tests for context manager to make sure it normalizes line endings
+   * Tests for find ranges
+   */
+  const fileContexts = sessionContext.contextManager.getEditableFileContexts()
+  const blobContexts = sessionContext.contextManager.getBlobContexts()
+
+  const messages = createQuestionAnsweringWithContext(
+    fileContexts,
+    blobContexts,
+    sessionContext.configuration,
+  ).concat(messagesInput)
+
+  const logFilePath = (fileContext: FileContext) => {
+    const path = fileContext.filePathRelativeToWorkspace
+    // Assumes we are in .task/sessions
+    void sessionContext.highLevelLogger(`- [${path}](../../${path})\n`)
+  }
+
+  // Log files that we are submitting as context
+  void sessionContext.highLevelLogger(`\n## Files submitted:\n`)
+  for (const fileContext of fileContexts) {
+    logFilePath(fileContext)
+  }
+
+  /*
+   * Provider pointer to low level log for debugging,
+   * it wants a relative to workspace path for some reason The document path is
+   * .task/sessions/<id>-<weekday>.raw.md,
+   * so we need to go up two levels since the markdown file we are outputing to
+   * is in .task/sessions as well Likely not windows friendly as it uses /
+   */
+  const relativePath = vscode.workspace.asRelativePath(
+    sessionContext.markdownLowLevelFeedbackDocument.uri.path,
+  )
+  void sessionContext.highLevelLogger(
+    `\n\n[Raw LLM input + response](../../${relativePath}) [Debug]\n`,
+  )
+
+  const streamResult = await streamLlm(
+    messages,
+    sessionContext.lowLevelLogger,
+    sessionContext,
+  )
+  if (streamResult.type === 'error') {
+    void sessionContext.highLevelLogger(`\n\n${streamResult.error.message}\n`)
+    sessionContext.sessionAbortedEventEmitter.fire()
+    throw streamResult.error
+  }
+
+  const [rawLlmResponseStream, abortController] = streamResult.value
+
+  // Abort if requested
+  sessionContext.sessionAbortedEventEmitter.event(() => abortController.abort())
+
+  /*
+   * Design Shortcoming due to multi casting
+   * Parsing will be performed multiple times for the same payload,
+   * see openai.ts
+   */
+  const partialResultsStream = from(rawLlmResponseStream).pipe(
+    mapAsync(({ cumulativeResponse, delta }) => {
+      /*
+       * Try parsing the xml, even if it's complete it should still be able to
+       * apply the diffs
+       */
+      return cumulativeResponse
+    }),
+  )
+
+  return partialResultsStream
+}

--- a/src/multi-file-edit/v1/index.ts
+++ b/src/multi-file-edit/v1/index.ts
@@ -8,7 +8,6 @@ import { startInteractiveMultiFileApplication } from 'multi-file-edit/applyResol
 import { parsePartialMultiFileEdit } from './parse'
 import { makeToResolvedChangesTransformer } from './resolveTargetRange'
 import { SessionContext } from 'session'
-import { queueAnAppendToDocument } from 'helpers/fileSystem'
 
 import { map as mapAsync } from 'ix/asynciterable/operators'
 import { createMultiFileEditingMessages } from './prompt'
@@ -32,26 +31,14 @@ export async function startMultiFileEditing(sessionContext: SessionContext) {
     sessionContext.configuration,
   )
 
-  const highLevelLogger = (text: string) =>
-    queueAnAppendToDocument(
-      sessionContext.markdownHighLevelFeedbackDocument,
-      text,
-    )
-
-  const lowLevelLogger = (text: string) =>
-    queueAnAppendToDocument(
-      sessionContext.markdownLowLevelFeedbackDocument,
-      text,
-    )
-
   const logFilePath = (fileContext: FileContext) => {
     const path = fileContext.filePathRelativeToWorkspace
     // Assumes we are in .task/sessions
-    void highLevelLogger(`- [${path}](../../${path})\n`)
+    void sessionContext.highLevelLogger(`- [${path}](../../${path})\n`)
   }
 
   // Log files that we are submitting as context
-  void highLevelLogger(`\n## Files submitted:\n`)
+  void sessionContext.highLevelLogger(`\n## Files submitted:\n`)
   for (const fileContext of fileContexts) {
     logFilePath(fileContext)
   }
@@ -66,13 +53,17 @@ export async function startMultiFileEditing(sessionContext: SessionContext) {
   const relativePath = vscode.workspace.asRelativePath(
     sessionContext.markdownLowLevelFeedbackDocument.uri.path,
   )
-  void highLevelLogger(
+  void sessionContext.highLevelLogger(
     `\n\n[Raw LLM input + response](../../${relativePath}) [Debug]\n`,
   )
 
-  const streamResult = await streamLlm(messages, lowLevelLogger, sessionContext)
+  const streamResult = await streamLlm(
+    messages,
+    sessionContext.lowLevelLogger,
+    sessionContext,
+  )
   if (streamResult.type === 'error') {
-    void highLevelLogger(`\n\n${streamResult.error.message}\n`)
+    void sessionContext.highLevelLogger(`\n\n${streamResult.error.message}\n`)
     sessionContext.sessionAbortedEventEmitter.fire()
     return
   }
@@ -107,10 +98,10 @@ export async function startMultiFileEditing(sessionContext: SessionContext) {
   async function showPlanAsItBecomesAvailable() {
     const planStream = parsedPatchStream.pipe(mapAsync((x) => x.task))
     let lastPlan = ''
-    void highLevelLogger(`\n## Task:\n`)
+    void sessionContext.highLevelLogger(`\n## Task:\n`)
     for await (const plan of planStream) {
       const delta = plan.slice(lastPlan.length)
-      void highLevelLogger(delta)
+      void sessionContext.highLevelLogger(delta)
       lastPlan = plan
     }
   }

--- a/src/notebook/addToTask.ts
+++ b/src/notebook/addToTask.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
-const pendingEdits = new Map<string, Promise<void>>()
-const documentContents = new Map<
+export const pendingEdits = new Map<string, Promise<void>>()
+export const documentContents = new Map<
   string,
   { kind: number; language: string; value: string }[]
 >()
@@ -81,7 +81,7 @@ export async function queueAnAppendToMarkdownValue(
  */
 
 // THIS WILL LEAK MEMORY!! Probably move to session scope
-const currentCellOutputContentMap = new Map<string, string>()
+export const currentCellOutputContentMap = new Map<string, string>()
 export async function queueAnAppendToExecutionOutput(
   execution: vscode.NotebookCellExecution,
   text: string,

--- a/src/notebook/addToTask.ts
+++ b/src/notebook/addToTask.ts
@@ -66,3 +66,48 @@ export async function queueAnAppendToMarkdownValue(
 
   await editPromise
 }
+
+/*
+ * COPIED OVER FROM ABOVE
+ *
+ * HACCCCK
+ * Sharing pending edits with the other function
+ *
+ * This is currently limited to append to append to the first cell in the
+ * notebook.
+ *
+ * Lets replace this with appending to output of the last cell.
+ *
+ */
+
+// THIS WILL LEAK MEMORY!! Probably move to session scope
+const currentCellOutputContentMap = new Map<string, string>()
+export async function queueAnAppendToExecutionOutput(
+  execution: vscode.NotebookCellExecution,
+  text: string,
+) {
+  const cellId = execution.cell.document.uri.toString()
+  const previousEdit = pendingEdits.get(cellId)
+  const applyEdit = async () => {
+    let currentCellOutput = currentCellOutputContentMap.get(cellId)
+    if (!currentCellOutput) {
+      currentCellOutput = ''
+    }
+
+    // Append text to the value of the first object in the array
+
+    currentCellOutput += text
+    currentCellOutputContentMap.set(cellId, currentCellOutput)
+
+    await execution.replaceOutput(
+      new vscode.NotebookCellOutput([
+        vscode.NotebookCellOutputItem.text(currentCellOutput, 'text/markdown'),
+      ]),
+    )
+  }
+
+  const editPromise = previousEdit ? previousEdit.then(applyEdit) : applyEdit()
+  pendingEdits.set(cellId, editPromise)
+
+  await editPromise
+}

--- a/src/notebook/addToTask.ts
+++ b/src/notebook/addToTask.ts
@@ -6,6 +6,13 @@ const documentContents = new Map<
   { kind: number; language: string; value: string }[]
 >()
 
+/*
+ * This is currently limited to append to append to the first cell in the
+ * notebook.
+ *
+ * Lets replace this with appending to output of the last cell.
+ *
+ */
 export async function queueAnAppendToMarkdownValue(
   document: vscode.TextDocument,
   text: string,
@@ -47,6 +54,7 @@ export async function queueAnAppendToMarkdownValue(
     }
 
     // Append text to the value of the first object in the array
+
     currentContentArray[0].value += text
 
     const data = new TextEncoder().encode(JSON.stringify(currentContentArray))

--- a/src/notebook/addToTask.ts
+++ b/src/notebook/addToTask.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode'
+
+const pendingEdits = new Map<string, Promise<void>>()
+const documentContents = new Map<
+  string,
+  { kind: number; language: string; value: string }[]
+>()
+
+export async function queueAnAppendToMarkdownValue(
+  document: vscode.TextDocument,
+  text: string,
+) {
+  const path = document.uri.path
+  const previousEdit = pendingEdits.get(path)
+  const applyEdit = async () => {
+    let currentContentArray = documentContents.get(path)
+    if (!currentContentArray) {
+      const currentContent = document.getText()
+      try {
+        currentContentArray = JSON.parse(currentContent) as
+          | {
+              kind: number
+              language: string
+              value: string
+            }[]
+          | undefined
+        if (!Array.isArray(currentContentArray)) {
+          throw new Error('Content does not have the expected array format')
+        }
+      } catch (e) {
+        /*
+         * If parsing failed or content is not an array,
+         * initialize with default structure
+         */
+        currentContentArray = [{ kind: 1, language: 'markdown', value: '' }]
+      }
+
+      /*
+       * Check if the first object has the expected format. If not,
+       * replace it with the default structure
+       */
+      if (currentContentArray[0]?.value === undefined) {
+        currentContentArray[0] = { kind: 1, language: 'markdown', value: '' }
+      }
+
+      documentContents.set(path, currentContentArray)
+    }
+
+    // Append text to the value of the first object in the array
+    currentContentArray[0].value += text
+
+    const data = new TextEncoder().encode(JSON.stringify(currentContentArray))
+    await vscode.workspace.fs.writeFile(document.uri, data)
+  }
+
+  const editPromise = previousEdit ? previousEdit.then(applyEdit) : applyEdit()
+  pendingEdits.set(document.uri.toString(), editPromise)
+
+  await editPromise
+}

--- a/src/notebook/taskAppendAnswerToOutput.ts
+++ b/src/notebook/taskAppendAnswerToOutput.ts
@@ -5,9 +5,20 @@ export function taskAppendAnswerToOutput(
   text: string,
 ) {
   void execution.clearOutput()
-  void execution.appendOutput([
+  void execution.appendOutput(
     new vscode.NotebookCellOutput([
       vscode.NotebookCellOutputItem.text(text, 'text/markdown'),
     ]),
-  ])
+  )
+}
+
+export function taskAppendWithoutErasing(
+  execution: vscode.NotebookCellExecution,
+  text: string,
+) {
+  void execution.appendOutput(
+    new vscode.NotebookCellOutput([
+      vscode.NotebookCellOutputItem.text(text, 'text/markdown'),
+    ]),
+  )
 }

--- a/src/notebook/taskAppendAnswerToOutput.ts
+++ b/src/notebook/taskAppendAnswerToOutput.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode'
+
+export function taskAppendAnswerToOutput(
+  execution: vscode.NotebookCellExecution,
+  text: string,
+) {
+  void execution.clearOutput()
+  void execution.appendOutput([
+    new vscode.NotebookCellOutput([
+      vscode.NotebookCellOutputItem.text(text, 'text/markdown'),
+    ]),
+  ])
+}

--- a/src/notebook/taskAppendAnswerToOutput.ts
+++ b/src/notebook/taskAppendAnswerToOutput.ts
@@ -12,6 +12,10 @@ export function taskAppendAnswerToOutput(
   )
 }
 
+/*
+ * ALright, we need to re-write the whole thing ...
+ * that sucks ...
+ */
 export function taskAppendWithoutErasing(
   execution: vscode.NotebookCellExecution,
   text: string,

--- a/src/notebook/taskController.ts
+++ b/src/notebook/taskController.ts
@@ -1,0 +1,53 @@
+import { getAnswer } from 'helpers/openai'
+import * as vscode from 'vscode'
+
+export class TaskController {
+  readonly controllerId = 'task-controller-id'
+  readonly notebookType = 'task-notebook'
+  readonly label = 'Task Notebook'
+  readonly supportedLanguages = ['task-book']
+
+  private readonly _controller: vscode.NotebookController
+  private _executionOrder = 0
+
+  constructor() {
+    this._controller = vscode.notebooks.createNotebookController(
+      this.controllerId,
+      this.notebookType,
+      this.label,
+    )
+
+    this._controller.supportedLanguages = this.supportedLanguages
+    this._controller.supportsExecutionOrder = true
+    this._controller.executeHandler = this._execute.bind(this)
+  }
+
+  dispose(): void {
+    this._controller.dispose()
+  }
+
+  private _execute(
+    cells: vscode.NotebookCell[],
+    _notebook: vscode.NotebookDocument,
+    _controller: vscode.NotebookController,
+  ): void {
+    for (const cell of cells) {
+      void this._doExecution(cell)
+    }
+  }
+
+  private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
+    const execution = this._controller.createNotebookCellExecution(cell)
+    execution.executionOrder = ++this._executionOrder
+    execution.start(Date.now())
+    void execution.clearOutput()
+
+    execution.token.onCancellationRequested(() => {
+      execution.end(true, Date.now())
+    })
+
+    await getAnswer(cell.document.getText(), execution)
+
+    execution.end(true, Date.now())
+  }
+}

--- a/src/notebook/taskController.ts
+++ b/src/notebook/taskController.ts
@@ -40,10 +40,21 @@ export class TaskController {
     const execution = this._controller.createNotebookCellExecution(cell)
     execution.executionOrder = ++this._executionOrder
     execution.start(Date.now())
+
+    /*
+     * Check if cell has @ task mention and kick off task if yes,
+     * passing execution
+     */
+
     void execution.clearOutput()
 
     execution.token.onCancellationRequested(() => {
-      execution.end(true, Date.now())
+      /*
+       * I think we would need to add a hook to stop openai request here.
+       * I think this was causing the double promise rejection error.
+       *
+       * execution.end(true, Date.now())
+       */
     })
 
     await getAnswer(cell.document.getText(), execution)

--- a/src/notebook/taskSerializer.ts
+++ b/src/notebook/taskSerializer.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import * as vscode from 'vscode'
+
+interface RawNotebookCell {
+  language: string
+  value: string
+  kind: vscode.NotebookCellKind
+  editable?: boolean
+  outputs: RawCellOutput[]
+}
+
+interface RawCellOutput {
+  mime: string
+  value: any
+}
+
+export class TaskSerializer implements vscode.NotebookSerializer {
+  async deserializeNotebook(
+    content: Uint8Array,
+    _token: vscode.CancellationToken,
+  ): Promise<vscode.NotebookData> {
+    const contents = new TextDecoder().decode(content)
+
+    let raw: RawNotebookCell[]
+    try {
+      raw = JSON.parse(contents) as RawNotebookCell[]
+    } catch {
+      raw = []
+    }
+
+    function convertRawOutputToBytes(raw: RawNotebookCell) {
+      const result: vscode.NotebookCellOutputItem[] = []
+      let markdown = ''
+
+      for (const output of raw.outputs) {
+        if (output.mime === 'text/markdown') {
+          markdown += JSON.stringify(output.value).slice(1, -1)
+        } else {
+          const data = new TextEncoder().encode(JSON.stringify(output.value))
+          result.push(new vscode.NotebookCellOutputItem(data, output.mime))
+        }
+      }
+
+      const data = new TextEncoder().encode(markdown.replace(/\\n/g, '\n'))
+      const markdownOutput = new vscode.NotebookCellOutputItem(
+        data,
+        'text/markdown',
+      )
+
+      result.unshift(markdownOutput)
+
+      return result
+    }
+
+    // Create array of Notebook cells for the VS Code API from file contents
+    const cells = raw.map(
+      (item) =>
+        new vscode.NotebookCellData(item.kind, item.value, item.language),
+    )
+
+    for (let i = 0; i < cells.length; i++) {
+      const cell = cells[i]
+      cell.outputs = raw[i].outputs
+        ? [new vscode.NotebookCellOutput(convertRawOutputToBytes(raw[i]))]
+        : []
+    }
+
+    /*
+     * Pass read and formatted Notebook Data to VS Code to display Notebook
+     * with saved cells
+     */
+    return new vscode.NotebookData(cells)
+  }
+
+  async serializeNotebook(
+    data: vscode.NotebookData,
+    _token: vscode.CancellationToken,
+  ): Promise<Uint8Array> {
+    // function to take output renderer data to a format to save to the file
+    function asRawOutput(cell: vscode.NotebookCellData): RawCellOutput[] {
+      const result: RawCellOutput[] = []
+      for (const output of cell.outputs ?? []) {
+        for (const item of output.items) {
+          let outputContents = ''
+          try {
+            outputContents = new TextDecoder().decode(item.data)
+          } catch {}
+
+          try {
+            const outputData = JSON.parse(outputContents)
+            result.push({ mime: item.mime, value: outputData })
+          } catch {
+            result.push({ mime: item.mime, value: outputContents })
+          }
+        }
+      }
+      return result
+    }
+
+    /*
+     * Map the Notebook data into the format we want to save the Notebook data
+     * as
+     */
+
+    const contents: RawNotebookCell[] = []
+
+    for (const cell of data.cells) {
+      contents.push({
+        kind: cell.kind,
+        language: cell.languageId,
+        value: cell.value,
+        outputs: asRawOutput(cell),
+      })
+    }
+
+    // Give a string of all the data to save and VS Code will handle the rest
+    return new TextEncoder().encode(JSON.stringify(contents))
+  }
+}

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,6 +1,11 @@
 import { SessionContextManager } from 'context/manager'
 import { queueAnAppendToDocument } from 'helpers/fileSystem'
-import { queueAnAppendToExecutionOutput } from 'notebook/addToTask'
+import {
+  currentCellOutputContentMap,
+  documentContents,
+  pendingEdits,
+  queueAnAppendToExecutionOutput,
+} from 'notebook/addToTask'
 import * as vscode from 'vscode'
 
 export interface SessionConfiguration {
@@ -277,6 +282,11 @@ export async function closeSession(
 
   sessionContext.sessionEndedEventEmitter.fire()
   sessionContext.sessionEndedEventEmitter.dispose()
+
+  ///// HACCCCCCCCKs HACK:
+  currentCellOutputContentMap.clear()
+  documentContents.clear()
+  pendingEdits.clear()
 }
 
 export async function findMostRecentSessionLogIndexPrefix(

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,4 +1,6 @@
 import { SessionContextManager } from 'context/manager'
+import { queueAnAppendToDocument } from 'helpers/fileSystem'
+import { queueAnAppendToMarkdownValue } from 'notebook/addToTask'
 import * as vscode from 'vscode'
 
 export interface SessionConfiguration {
@@ -21,7 +23,11 @@ export interface SessionContext {
    * This will be open to the side to show real time feedback of what is
    * happening in the session.
    */
-  markdownHighLevelFeedbackDocument: vscode.TextDocument
+  highLevelFeedbackDocument: vscode.TextDocument
+
+  lowLevelLogger: (text: string) => Promise<void>
+
+  highLevelLogger: (text: string) => Promise<void>
 
   /**
    * This is the document where raw LLM request is logged. This is mostly for
@@ -71,10 +77,23 @@ export async function startSession(
     )
   }
 
+  const markdownOrNotebook = vscode.workspace
+    .getConfiguration('ai-task')
+    .get<string>('markdownOrNotebook')!
+
   const {
-    sessionMarkdownHighLevelFeedbackDocument,
+    sessionHighLevelFeedbackDocument,
     sessionMarkdownLowLevelFeedbackDocument,
-  } = await createSessionLogDocuments()
+  } = await createSessionLogDocuments(markdownOrNotebook)
+
+  const lowLevelLogger = (text: string) =>
+    queueAnAppendToDocument(sessionMarkdownLowLevelFeedbackDocument, text)
+
+  const highLevelLogger = (text: string) => {
+    return markdownOrNotebook === 'markdown'
+      ? queueAnAppendToDocument(sessionHighLevelFeedbackDocument, text)
+      : queueAnAppendToMarkdownValue(sessionHighLevelFeedbackDocument, text)
+  }
 
   const cachedActiveEditor = vscode.window.activeTextEditor
 
@@ -82,10 +101,19 @@ export async function startSession(
    * Since we're opening to the side the focus is not taken.
    * Remove for recording simple demo
    */
-  await vscode.commands.executeCommand(
-    'markdown.showPreviewToSide',
-    sessionMarkdownHighLevelFeedbackDocument.uri,
-  )
+
+  if (markdownOrNotebook === 'markdown') {
+    await vscode.commands.executeCommand(
+      'markdown.showPreviewToSide',
+      sessionHighLevelFeedbackDocument.uri,
+    )
+  } else {
+    await vscode.commands.executeCommand(
+      'vscode.open',
+      sessionHighLevelFeedbackDocument.uri,
+      vscode.ViewColumn.Beside,
+    )
+  }
 
   // Restore the focus
   if (cachedActiveEditor) {
@@ -122,7 +150,7 @@ export async function startSession(
            * 'Preview'
            */
           const abortSignalDocumentName =
-            sessionMarkdownHighLevelFeedbackDocument.uri.path.split('/').at(-1)!
+            sessionHighLevelFeedbackDocument.uri.path.split('/').at(-1)!
           return tab.label.includes(abortSignalDocumentName)
         })
       ) {
@@ -177,7 +205,9 @@ export async function startSession(
       includeLineNumbers: true,
       enableNewFilesAndShellCommands: true,
     },
-    markdownHighLevelFeedbackDocument: sessionMarkdownHighLevelFeedbackDocument,
+    lowLevelLogger: lowLevelLogger,
+    highLevelLogger: highLevelLogger,
+    highLevelFeedbackDocument: sessionHighLevelFeedbackDocument,
     markdownLowLevelFeedbackDocument: sessionMarkdownLowLevelFeedbackDocument,
     contextManager: documentManager,
     sessionAbortedEventEmitter,
@@ -190,7 +220,7 @@ export async function startSession(
 export async function closeSession(
   sessionContext: SessionContext,
 ): Promise<void> {
-  await sessionContext.markdownHighLevelFeedbackDocument.save()
+  await sessionContext.highLevelFeedbackDocument.save()
   await sessionContext.markdownLowLevelFeedbackDocument.save()
 
   /*
@@ -251,7 +281,7 @@ async function findMostRecentSessionLogIndexPrefix(
   return mostRecentSessionLogIndexPrefix
 }
 
-async function createSessionLogDocuments() {
+async function createSessionLogDocuments(markdownOrNotebook: string) {
   const taskMagicIdentifier = getBreadIdentifier()
   const sessionsDirectory = vscode.Uri.joinPath(
     vscode.workspace.workspaceFolders![0].uri,
@@ -267,11 +297,16 @@ async function createSessionLogDocuments() {
   const sessionNameBeforeAddingTopicSuffix = `${nextIndex}-${shortWeekday}`
 
   // High level feedback
-  const sessionMarkdownHighLevelFeedbackDocument =
-    await createAndOpenEmptyDocument(
-      sessionsDirectory,
-      `${sessionNameBeforeAddingTopicSuffix}.md`,
-    )
+  const sessionHighLevelFeedbackDocument =
+    markdownOrNotebook === 'markdown'
+      ? await createAndOpenEmptyDocument(
+          sessionsDirectory,
+          `${sessionNameBeforeAddingTopicSuffix}.md`,
+        )
+      : await createAndOpenEmptyDocument(
+          sessionsDirectory,
+          `${sessionNameBeforeAddingTopicSuffix}.task`,
+        )
   // Low level feedback
   const sessionMarkdownLowLevelFeedbackDocument =
     await createAndOpenEmptyDocument(
@@ -280,7 +315,7 @@ async function createSessionLogDocuments() {
     )
 
   return {
-    sessionMarkdownHighLevelFeedbackDocument,
+    sessionHighLevelFeedbackDocument,
     sessionMarkdownLowLevelFeedbackDocument,
   }
 }

--- a/testing-sandbox/helloWorld.ts
+++ b/testing-sandbox/helloWorld.ts
@@ -1,4 +1,3 @@
-//  @task @errors Parametrize this function with a name and remove this comment line. Don't use semi-colons in the end of lines. 
-export function helloWorld() {
-  console.log(`Hello World!`)
+export function helloWorld(name: string) {
+  console.log(`Hello ${name}!`)
 }

--- a/testing-sandbox/kek.task
+++ b/testing-sandbox/kek.task
@@ -1,0 +1,1 @@
+[{"kind":2,"language":"task-book","value":"@task @run @errors @tabs","outputs":[{"mime":"text/markdown","value":"В JavaScript есть ещё и специальные значения, которые не относятся к типам данных вы"}]}]


### PR DESCRIPTION
> Disclaimer on hacks - we have 5 demo's tomorrow morning so trying to finish this up asap because it seems crucial to have for the demos

## New control flow

When user hits run (or runs command from command palette)
  - we create a new notebook
  - open it
  - do gynmnastics to add a new cell to it using commands (so if its already opend we append to the end)
  - start executing the cell

Now all actual file editing is kicked off from the notebook execution
  - We create a new session, given the cell execution to append high level results to
  - If the cell does not have a task in it
    - Similar to how we do this in completeInlineTasks, parse the cell content for @ mentions and modify context
    - use a simplified prompt to simply generate markdown reponse - no edits
    - dump context manager + previous cell contents into the messages

## Fixups:
- Create a cell with markdown showing discord link
- Smaller heading size for files / task etc - takes too much space
- In output remove start / end messages - redundant
- Editing is happening not in the original tab group, but in the group with the notebook. We should keep the notebook visible and open the files in the original group. I think this can be accessed from tabs api. Search tabs in the codebase.

## If we have time
- Allow writing custom tasks in the notebook and actually running file editing on those
- There is some command @command:notebook.action.toggleNotebookStickyScroll (open command pallet and explore "Notebook: " commands). No idea what this does, but might help with keeping the bottom part visible
